### PR TITLE
Permit the use of a custom runtime

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,6 +18,10 @@ cargo install -f cargo-libafl
 cargo libafl --help
 ```
 
+### Custom Runtimes
+
+If you need to use a custom runtime for your target, e.g. when using custom mutators, define an environmental variable `CUSTOM_LIBAFL_RUNTIME` to the target/release folder of your runtime. Note that your runtime should match the name (`cargo-libafl-runtime`) and the flags of the original runtime. To do this effectively, you should copy the `cargo-libafl-runtime` folder and modify it to your needs.
+
 #### License
 
 <sup>

--- a/cargo-libafl/src/common.rs
+++ b/cargo-libafl/src/common.rs
@@ -44,7 +44,11 @@ pub fn runtime_dir() -> PathBuf {
 
 #[cfg(not(docsrs))]
 pub fn runtime_dir() -> PathBuf {
-    xdg_dir().create_data_directory("cargo-libafl").unwrap()
+    if let Some(custom_dir) = std::env::var_os("CUSTOM_LIBAFL_RUNTIME") {
+        PathBuf::from(custom_dir)
+    } else {
+        xdg_dir().create_data_directory("cargo-libafl").unwrap()
+    }
 }
 
 #[allow(dead_code)]


### PR DESCRIPTION
For a particular target, it was advantageous for me to use a separate cargo-libafl-runtime provided as I need custom mutations.

This PR merely adds an environmental variable, `CUSTOM_LIBAFL_RUNTIME`, which will be used to resolve the `libcargo_libafl_runtime.a` instead of the base one.