### PR TITLE
runtime: complete rev hash

### DIFF
--- a/cargo-libafl/cargo-libafl-runtime/Cargo.toml
+++ b/cargo-libafl/cargo-libafl-runtime/Cargo.toml
@@ -13,8 +13,8 @@ edition = "2021"
 [workspace]
 
 [dependencies]
-libafl = { git = "https://github.com/AFLplusplus/LibAFL.git", rev = "4375206" }
-libafl_targets = { git = "https://github.com/AFLplusplus/LibAFL.git", rev = "4375206", features = ["sancov_8bit", "sancov_cmplog"] }
+libafl = { git = "https://github.com/AFLplusplus/LibAFL.git", rev = "43752062f1c6078a7e97b3ca1327d55e8a6ea044" }
+libafl_targets = { git = "https://github.com/AFLplusplus/LibAFL.git", rev = "43752062f1c6078a7e97b3ca1327d55e8a6ea044", features = ["sancov_8bit", "sancov_cmplog"] }
 mimalloc = { version = "*", default-features = false }
 portpicker = "0.1.1"
 clap = { version = "3.2", features = ["derive"] }


### PR DESCRIPTION
I am currently unable to build the project do to the following error:
```
error: failed to run custom build command for `cargo-libafl v0.1.8 (.../cargo-libafl/cargo-libafl)`

Caused by:
  process didn't exit successfully: `.../cargo-libafl/target/release/build/cargo-libafl-1248d1c4679292ec/build-script-build` (exit status: 101)
  --- stdout
  cargo:rustc-env=TARGET=x86_64-unknown-linux-gnu
  cargo:rerun-if-changed=build.rs
  cargo:rerun-if-changed=cargo-libafl-runtime/runtime.rs
  cargo:rerun-if-changed=cargo-libafl-runtime/Cargo.toml

  --- stderr
      Updating crates.io index
      Updating git repository `https://github.com/AFLplusplus/LibAFL.git`
  error: failed to get `libafl` as a dependency of package `cargo-libafl-runtime v0.1.8 (.../cargo-libafl/target/release/build/cargo-libafl-d0f2e223ee34551f/out)`

  Caused by:
    failed to load source for dependency `libafl`

  Caused by:
    Unable to update https://github.com/AFLplusplus/LibAFL.git?rev=4375206

  Caused by:
    revspec '4375206' not found; class=Reference (4); code=NotFound (-3)
  thread 'main' panicked at 'assertion failed: Command::new(\"cargo\").current_dir(&out_path).env(\"CARGO_TARGET_DIR\",
    out_path.join(\"rt\")).arg(\"build\").arg(&format!(\"--manifest-path={}/Cargo.toml\",
    out_dir)).arg(\"--release\").status().unwrap().success()', cargo-libafl/build.rs:50:5
```

This PR fixes that issue by using the full hash to pin the correct revision.