### PR TITLE
improve cargo fuzz compat and bump to newer libAFL version

### DIFF
--- a/cargo-libafl/Cargo.toml
+++ b/cargo-libafl/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "cargo-libafl"
-version = "0.1.8"
+version = "0.1.9"
 authors = ["Andrea Fioraldi <andreafioraldi@gmail.com>"]
 license = "MIT OR Apache-2.0"
 description = "A `cargo` wrapper to fuzz Rust code with `LibAFL`"
@@ -28,3 +28,7 @@ toml = "0.5.9"
 cargo-binutils = "0.3.6"
 rustc_version = "0.4"
 xdg = "2.4"
+
+[features]
+sancov_8bit = []
+tui = []

--- a/cargo-libafl/Cargo.toml
+++ b/cargo-libafl/Cargo.toml
@@ -30,5 +30,6 @@ rustc_version = "0.4"
 xdg = "2.4"
 
 [features]
+default = ["sancov_8bit"]
 sancov_8bit = []
 tui = []

--- a/cargo-libafl/build.rs
+++ b/cargo-libafl/build.rs
@@ -47,10 +47,15 @@ fn main() {
     fs::copy(rt_path.join("runtime.rs"), out_path.join("runtime.rs"))
         .expect("Couldn't copy runtime.rs");
 
-    assert!(Command::new("cargo")
-        .current_dir(&out_path)
+    let mut cmd = Command::new("cargo");
+    cmd.current_dir(&out_path)
         .env("CARGO_TARGET_DIR", out_path.join("rt"))
-        .arg("build")
+        .arg("build");
+    #[cfg(feature = "sancov_8bit")]
+    cmd.arg("--features").arg("sancov_8bit");
+    #[cfg(feature = "tui")]
+    cmd.arg("--features").arg("tui");
+    assert!(cmd
         .arg(&format!("--manifest-path={}/Cargo.toml", out_dir))
         .arg("--release")
         .status()

--- a/cargo-libafl/build.rs
+++ b/cargo-libafl/build.rs
@@ -51,6 +51,7 @@ fn main() {
     cmd.current_dir(&out_path)
         .env("CARGO_TARGET_DIR", out_path.join("rt"))
         .arg("build");
+    cmd.arg("--no-default-features");
     #[cfg(feature = "sancov_8bit")]
     cmd.arg("--features").arg("sancov_8bit");
     #[cfg(feature = "tui")]

--- a/cargo-libafl/cargo-libafl-runtime/Cargo.toml
+++ b/cargo-libafl/cargo-libafl-runtime/Cargo.toml
@@ -13,11 +13,15 @@ edition = "2021"
 [workspace]
 
 [dependencies]
-libafl = { git = "https://github.com/AFLplusplus/LibAFL.git", rev = "7ed1ac9" }
-libafl_targets = { git = "https://github.com/AFLplusplus/LibAFL.git", rev = "7ed1ac9", features = ["sancov_8bit", "sancov_cmplog"] }
+libafl = { git = "https://github.com/AFLplusplus/LibAFL.git", rev = "8ff8ae41f1ed2956bb1e906c5c7bd0505ca110c0" }
+libafl_targets = { git = "https://github.com/AFLplusplus/LibAFL.git", rev = "8ff8ae41f1ed2956bb1e906c5c7bd0505ca110c0", features = ["sancov_8bit", "sancov_pcguard",
+"sancov_cmplog", "pointer_maps"] }
+
 mimalloc = { version = "*", default-features = false }
 portpicker = "0.1.1"
 clap = { version = "4.0", features = ["derive"] }
+env_logger = "0.10"
+log = "*"
 
 [profile.release]
 lto = true
@@ -28,3 +32,7 @@ debug = true
 [lib]
 crate-type = ["staticlib", "rlib"]
 path = "runtime.rs"
+
+[features]
+sancov_8bit = []
+tui = []

--- a/cargo-libafl/cargo-libafl-runtime/Cargo.toml
+++ b/cargo-libafl/cargo-libafl-runtime/Cargo.toml
@@ -13,9 +13,8 @@ edition = "2021"
 [workspace]
 
 [dependencies]
-libafl = { git = "https://github.com/AFLplusplus/LibAFL.git", rev = "8ff8ae41f1ed2956bb1e906c5c7bd0505ca110c0" }
-libafl_targets = { git = "https://github.com/AFLplusplus/LibAFL.git", rev = "8ff8ae41f1ed2956bb1e906c5c7bd0505ca110c0", features = ["sancov_8bit", "sancov_pcguard",
-"sancov_cmplog", "pointer_maps"] }
+libafl = { git = "https://github.com/AFLplusplus/LibAFL.git", rev = "721c02c" }
+libafl_targets = { git = "https://github.com/AFLplusplus/LibAFL.git", rev = "721c02c", features = ["sancov_8bit", "sancov_pcguard", "sancov_cmplog", "pointer_maps"] }
 
 mimalloc = { version = "*", default-features = false }
 portpicker = "0.1.1"

--- a/cargo-libafl/cargo-libafl-runtime/Cargo.toml
+++ b/cargo-libafl/cargo-libafl-runtime/Cargo.toml
@@ -5,22 +5,24 @@ name = "cargo-libafl-runtime"
 # 13.3.7 is a dummy value for templating purposes, it will be replaced with the actual version by ../build.rs
 version = "13.3.7"
 authors = ["Andrea Fioraldi <andreafioraldi@gmail.com>"]
-license = "MIT OR Apache-2.0"
-description = "The runtime lib for cargo-libafl"
-repository = "https://github.com/AFLplusplus/cargo-libafl"
 edition = "2021"
+license = "MIT OR Apache-2.0"
+repository = "https://github.com/AFLplusplus/cargo-libafl"
+description = "The runtime lib for cargo-libafl"
 
 [workspace]
 
 [dependencies]
-libafl = { git = "https://github.com/AFLplusplus/LibAFL.git", rev = "721c02c" }
-libafl_targets = { git = "https://github.com/AFLplusplus/LibAFL.git", rev = "721c02c", features = ["sancov_8bit", "sancov_pcguard", "sancov_cmplog", "pointer_maps"] }
+libafl = { git = "https://github.com/AFLplusplus/LibAFL.git", rev = "6d2284d" }
+libafl_targets = { git = "https://github.com/AFLplusplus/LibAFL.git", rev = "6d2284d", features = ["sancov_8bit", "sancov_pcguard", "sancov_cmplog", "pointer_maps"] }
+# libafl = "0.10"
+# libafl_targets = { version = "0.10", features = ["sancov_8bit", "sancov_pcguard", "sancov_cmplog", "pointer_maps"] }
 
-mimalloc = { version = "*", default-features = false }
-portpicker = "0.1.1"
 clap = { version = "4.0", features = ["derive"] }
 env_logger = "0.10"
 log = "*"
+mimalloc = { version = "*", default-features = false }
+portpicker = "0.1.1"
 
 [profile.release]
 lto = true

--- a/cargo-libafl/cargo-libafl-runtime/Cargo.toml
+++ b/cargo-libafl/cargo-libafl-runtime/Cargo.toml
@@ -33,5 +33,6 @@ crate-type = ["staticlib", "rlib"]
 path = "runtime.rs"
 
 [features]
+default = [ "sancov_8bit" ]
 sancov_8bit = []
 tui = []

--- a/cargo-libafl/cargo-libafl-runtime/runtime.rs
+++ b/cargo-libafl/cargo-libafl-runtime/runtime.rs
@@ -162,7 +162,7 @@ pub fn main() {
         rust_fuzzer_initialize();
     }
 
-    env_logger::init();
+    env_logger::Builder::from_env(env_logger::Env::default().default_filter_or("info")).init();
 
     let workdir = env::current_dir().unwrap();
 

--- a/cargo-libafl/cargo-libafl-runtime/runtime.rs
+++ b/cargo-libafl/cargo-libafl-runtime/runtime.rs
@@ -16,7 +16,7 @@ use libafl::{
         rands::StdRand,
         shmem::{ShMemProvider, StdShMemProvider},
         tuples::{tuple_list, Merge},
-        AsSlice,
+        AsMutSlice, AsSlice,
     },
     corpus::{self, CachedOnDiskCorpus, Corpus, OnDiskCorpus},
     events::EventConfig,
@@ -36,6 +36,7 @@ use libafl::{
         StdMOptMutator,
     },
     observers::{BacktraceObserver, TimeObserver},
+    prelude::OwnedMutSlice,
     schedulers::{
         powersched::PowerSchedule, IndexesLenTimeMinimizerScheduler, PowerQueueScheduler,
     },
@@ -218,9 +219,8 @@ pub fn main() {
 
         #[cfg(feature = "sancov_8bit")]
         let edges_observer = {
-            let edges = unsafe { &mut COUNTERS_MAPS };
-            // TODO: is the call to edges.clone here the reason for breaking sancov_8bit?
-            HitcountsIterableMapObserver::new(MultiMapObserver::new("edges", edges.clone()))
+            let edges = unsafe { COUNTERS_MAPS.drain(0..).collect() };
+            HitcountsIterableMapObserver::new(MultiMapObserver::new("edges", edges))
         };
 
         #[cfg(not(feature = "sancov_8bit"))]

--- a/cargo-libafl/cargo-libafl-runtime/runtime.rs
+++ b/cargo-libafl/cargo-libafl-runtime/runtime.rs
@@ -235,6 +235,14 @@ pub fn main() {
 
         #[cfg(feature = "sancov_8bit")]
         let edges_observer = {
+            // libAFL 0.10
+            // let edges = unsafe {
+            //     COUNTERS_MAPS
+            //         .drain(0..)
+            //         .map(|x| OwnedMutSlice::from_raw_parts_mut(x.as_mut_ptr(), x.len()))
+            //         .collect()
+            // };
+            // libAFL git
             let edges = unsafe { COUNTERS_MAPS.drain(0..).collect() };
             HitcountsIterableMapObserver::new(MultiMapObserver::new("edges", edges))
         };

--- a/cargo-libafl/src/project.rs
+++ b/cargo-libafl/src/project.rs
@@ -163,9 +163,16 @@ impl FuzzProject {
             cmd.arg("-Z").arg("build-std");
         }
 
+        #[cfg(feature = "sancov_8bit")]
         let mut rustflags: String = "-Cpasses=sancov-module \
                                      -Cllvm-args=-sanitizer-coverage-level=4 \
                                      -Cllvm-args=-sanitizer-coverage-inline-8bit-counters \
+                                     -Cllvm-args=-sanitizer-coverage-pc-table"
+            .to_owned();
+        #[cfg(not(feature = "sancov_8bit"))]
+        let mut rustflags: String = "-Cpasses=sancov-module \
+                                     -Cllvm-args=-sanitizer-coverage-level=4 \
+                                     -Cllvm-args=-sanitizer-coverage-trace-pc-guard \
                                      -Cllvm-args=-sanitizer-coverage-pc-table"
             .to_owned();
 
@@ -264,8 +271,11 @@ impl FuzzProject {
             cmd.arg("--target-dir").arg(target_dir);
         }
 
-        let artifact_arg = ffi::OsString::from(self.artifacts_for(fuzz_target)?);
-        cmd.arg("--").arg("--output").arg(artifact_arg);
+        cmd.arg("--")
+            .arg("--corpus")
+            .arg(self.corpus_for(fuzz_target)?)
+            .arg("--crashes")
+            .arg(self.artifacts_for(fuzz_target)?);
 
         Ok(cmd)
     }


### PR DESCRIPTION

* use the same paths for corpus/crashes as cargo fuzz => this should allow mixing `cargo fuzz` and `cargo libafl`, i.e. use with a shared corpus.
* feature-guard the tui away and instead use `env_logger` by default. seemed more reasonable to me. maybe the default should be the other way around. let me know.
* bumped libAFL version, which breaks sancov 8bit inline counters for some reason. As a workaround I feature-guarded 8bit inline counters and instead use pcguard by default.

Any ideas why the sancov 8bit inline counters do not work anymore? it seems no feedback is observed.