### PR TITLE
DRAFT: added cli flags to enable "--careful" mode inspired by `cargo careful`

### DIFF
--- a/cargo-libafl/src/options.rs
+++ b/cargo-libafl/src/options.rs
@@ -98,6 +98,19 @@ pub struct BuildOptions {
     /// Use a specific sanitizer
     pub sanitizer: Sanitizer,
 
+    #[clap(long = "build-std")]
+    /// Pass `-Zbuild-std` to cargo to build the standard library with the same build settings as
+    /// the fuzz target, such as debug assertions and sanitizers. This allows to identify a more
+    /// diverse set of bugs. But beware, some sanitizers might cause false alarms with the standard
+    /// library (e.g., thread sanitizer). Currently this conflicts with source-based coverage
+    /// instrumentation.
+    pub build_std: bool,
+
+    #[clap(short, long = "careful")]
+    /// enable "careful" mode: inspired by https://github.com/RalfJung/cargo-careful, this enables building the
+    /// standard library (implies --build-std) with debug assertions and extra const UB and init checks.
+    pub careful_mode: bool,
+
     #[clap(
         name = "triple",
         long = "target",
@@ -229,6 +242,8 @@ mod test {
             no_default_features: false,
             all_features: false,
             features: None,
+            build_std: false,
+            careful_mode: false,
             sanitizer: Sanitizer::Address,
             triple: String::from(crate::utils::default_target()),
             unstable_flags: Vec::new(),

--- a/cargo-libafl/src/options/coverage.rs
+++ b/cargo-libafl/src/options/coverage.rs
@@ -3,7 +3,7 @@ use crate::{
     project::FuzzProject,
     RunCommand,
 };
-use anyhow::Result;
+use anyhow::{bail, Result};
 use clap::{self, Parser};
 
 #[derive(Clone, Debug, Parser)]
@@ -27,6 +27,13 @@ pub struct Coverage {
 
 impl RunCommand for Coverage {
     fn run_command(&mut self) -> Result<()> {
+        if self.build.build_std {
+            bail!(
+                "-Zbuild-std is currently incompatible with -Zinstrument-coverage, \
+                    see https://github.com/rust-lang/wg-cargo-std-aware/issues/63"
+            );
+        }
+
         let project = FuzzProject::new(self.fuzz_dir_wrapper.fuzz_dir.clone())?;
         self.build.coverage = true;
         project.exec_coverage(self)


### PR DESCRIPTION
* based on [this PR](https://github.com/rust-fuzz/cargo-fuzz/pull/292) to `cargo-fuzz` by @saethlin
* based on [cargo-careful](https://github.com/RalfJung/cargo-careful) by @RalfJung

Problem is that passing `-Zbuild-std` breaks linking, because of duplicate symbols between the libafl runtime staticlib and the freshly built std crates.

I believe this is the relevant upstream issue: https://github.com/rust-lang/rust/issues/104707 also here https://github.com/rust-lang/rust/issues/44322#issuecomment-1310211971 and here https://alanwu.space/post/symbol-hygiene/